### PR TITLE
Creating Superbuild (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,13 @@ CMakeUserPresets.json
 *-prefix/
 
 # End of https://www.toptal.com/developers/gitignore/api/clion,cmake
+
+.vscode/*
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+# https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore
+
+demo/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,67 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(CMaizeSuperbuild VERSION 1.0.0 LANGUAGES CXX)
 
-include(ExternalProject) # For ExternalProject_Add command
-
 # This is where we will install artifacts during the build stage
 set(stage_directory "${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_PREFIX}")
 
+# Tell compiler to not include debug flags
+set(CMAKE_BUILD_TYPE_INIT "Release")
+
+# Add cmake config location to paths to search
+list(APPEND CMAKE_PREFIX_PATH ${stage_directory})
+
+include(ExternalProject)
+
+# Add project with no dependencies from git
+ExternalProject_Add(
+    CMakePublic
+    GIT_REPOSITORY "https://github.com/CMaizeExamples/CMakePublic"
+    CMAKE_ARGS
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+        -DCMAKE_INSTALL_PREFIX:PATH=${stage_directory}
+    BUILD_ALWAYS ON
+)
+
 # Builds the main library and installs it to the staging directory
+# Allows CMakePublic to build first since it's a dependency
 ExternalProject_Add(
     "${PROJECT_NAME}_core"
     SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/hello_world"
-    CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-	       -DCMAKE_INSTALL_PREFIX=${stage_directory}
-    BUILD_ALWAYS 1
+    CMAKE_ARGS
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+	    -DCMAKE_INSTALL_PREFIX:PATH=${stage_directory}
+        -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+    DEPENDS CMakePublic
+    BUILD_ALWAYS ON
 )
 
 # Installing a superbuild just means copying the stage directory to its final
 # location
 INSTALL(DIRECTORY "${stage_directory}/" DESTINATION ${CMAKE_INSTALL_PREFIX})
+
+# Building the tests is off by default and can be turned on
+# by adding -DBUILD_TESTING=ON when running cmake
+
+if(BUILD_TESTING)
+
+    # Testing doesn't need to be installed so it's overwritten with an echo
+    ExternalProject_Add(
+        "${PROJECT_NAME}_test"
+        SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/tests"
+        CMAKE_ARGS
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+            -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+        DEPENDS "${PROJECT_NAME}_core"
+        INSTALL_COMMAND cmake -E echo "Skipping install step."
+        TEST_COMMAND
+        BUILD_ALWAYS ON
+    )
+
+    # Include directory that the test is built in
+    ExternalProject_Get_Property(${PROJECT_NAME}_test binary_dir)
+    file(APPEND ${CMAKE_BINARY_DIR}/CTestTestfile.cmake "SUBDIRS(${binary_dir})")
+    
+endif()

--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-# CMakeSuperbuild
-This is a repository regarding my work and research into developing a CMake build system using the super build model.
+# [Documentation](Documentation/CMakeSuperbuildModel.md)

--- a/hello_world/CMakeLists.txt
+++ b/hello_world/CMakeLists.txt
@@ -4,43 +4,77 @@ cmake_minimum_required(VERSION "${CMAKE_VERSION}")
 
 project(HelloWorld LANGUAGES CXX)
 
-# Used to deduce the directories for installation
+# Find external module CMakePublic
+# Location to config file given by CMAKE_PREFIX_PATH
+find_package(CMakePublic CONFIG REQUIRED)
+
+# Allows user to specify install dirs
 include(GNUInstallDirs)
 
-# Library names should be filesystem friendly name (so not case-sensitive)
-set(lib_name hello_world)
-
 # Declares a one-source library
-add_library(${lib_name} "${CMAKE_CURRENT_SOURCE_DIR}/src/hello-world.cpp")
+add_library(${PROJECT_NAME} STATIC "${CMAKE_CURRENT_SOURCE_DIR}/src/hello-world.cpp")
 
-# Declares that are library has one public header file
-set_target_properties(
-    ${lib_name} PROPERTIES PUBLIC_HEADER
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/hello-world.hpp"
+# Add library dependencies
+target_link_libraries(${PROJECT_NAME} PUBLIC CMakePublic::CMakePublic)
+
+# Declares that this library has one public header file
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/include/hello-world.hpp"
 )
 
-# Tells CMake where header files the target depends on can be found
-target_include_directories(
-    ${lib_name} PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
-    $<INSTALL_INTERFACE:include/>
+# Tells cmake that the header file can be found in hello_world/include during build
+# and then install_prefix/include during install
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-# Installs the library and header files and associates it with an export target
+# Installs the library and target
 # "${lib_name}-targets"
 install(
-    TARGETS ${lib_name}
-    EXPORT "${lib_name}-targets"
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR}
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}-targets
+    # Where to install the header file to
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/helloworld
+    # Where to install the static libraries (.a) to
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/helloworld
+    # Where to install the dynamic libraries (.dll/.so) to
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/helloworld
+    # Where to install the executalbe to
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/helloworld
 )
 
-# Installs the export target
+# Exports the HelloWorld target
+# Tells CMake where to find files and build this project
 install(
-    EXPORT ${lib_name}-targets
-    NAMESPACE ${lib_name}::
-    FILE ${lib_name}Config.cmake
-    DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake
+    EXPORT ${PROJECT_NAME}-targets
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/helloworld/cmake
+)
+
+
+#message("HELLO: ${CMAKE_CURRENT_LIST_DIR}")
+
+# Install header(s)
+# install(FILES ${CMAKE_CURRENT_LIST_DIR}/include/hello-world.hpp
+#   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+# )
+
+include(CMakePackageConfigHelpers)
+
+# Grab config template and add extra logic to it
+# Config template has info on dependencies
+set(config_file_name "${PROJECT_BINARY_DIR}/helloworld-config.cmake")
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
+    "${config_file_name}"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/helloworld
+)
+
+# Export package config file
+install(FILES
+    "${config_file_name}"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/helloworld/cmake
 )

--- a/hello_world/cmake/Config.cmake.in
+++ b/hello_world/cmake/Config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+check_required_components("@PROJECT_NAME@")
+
+include(CMakeFindDependencyMacro)
+find_dependency(CMakePublic)
+
+include("${CMAKE_CURRENT_LIST_DIR}/HelloWorld-targets.cmake")

--- a/hello_world/include/hello-world.hpp
+++ b/hello_world/include/hello-world.hpp
@@ -2,3 +2,4 @@
 #include <string>
 
 std::string say_hello();
+std::string say_goodbye();

--- a/hello_world/src/hello-world.cpp
+++ b/hello_world/src/hello-world.cpp
@@ -1,3 +1,10 @@
 #include "hello-world.hpp"
+#include "cmakepublic/cmake_public.hpp"
+
+std::string say_goodbye() {
+    int val = call_cmake_public();
+    std::string str = std::to_string(val);
+    return (std::string("Goodbye from CMake Public! ") + str);
+}
 
 std::string say_hello() { return std::string("Hello, CMake superbuild!"); }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION "${CMAKE_VERSION}")
+project(SuperTest LANGUAGES CXX)
+
+# Import the whole dependency tree
+#find_package(CMakePublic CONFIG REQUIRED)
+find_package(HelloWorld CONFIG REQUIRED)
+
+# Tell cmake to make this an executable
+add_executable(${PROJECT_NAME} test.cpp)
+
+# Link the hello-world library while compiling
+target_link_libraries(${PROJECT_NAME} PUBLIC HelloWorld::HelloWorld)
+
+# Add testing support
+include(CTest)
+
+# Add test to this build directory and link to it from the superbuild
+add_test(NewTest ${PROJECT_NAME})
+
+# Edit test to look at `stdout` rather then main's return value
+set_tests_properties(NewTest
+    PROPERTIES
+    PASS_REGULAR_EXPRESSION "Hello, CMake superbuild!\nGoodbye from CMake Public! 3\n"
+)

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,0 +1,12 @@
+/*
+ *  This file tests to see if hello-world runs without errors
+ */
+
+#include <iostream>
+#include "helloworld/hello-world.hpp"
+
+int main() {
+    std::cout << say_hello() << std::endl;
+    std::cout << say_goodbye() << std::endl;
+    return 0;
+}


### PR DESCRIPTION
* Add optional code dependancy for cmake_public

* - Update .gitignore for VSCode.
- Make CMakePublic Required and move #include to source file.

* - Edit top level CMakeLists to build CMakePublic from zip of current head.
- Removed /${CMAKE INSTALL_PREFIX} from end of stage_dir
- Note: Switching stage_directory to CMAKE_INSTALL_PREFIX causes CMakePublic to build in the default location.

* Remove iostream

* Top Level CMakeList
- Uncommented the external add for Hello_World.
- Added dependacy for CMakePublic to Hello_World.
- ReAdded CMAKE_INSTALL_PREFIX to stage_directory.

* Update hello-world CMakeList
- Change find package to look in folder rather than file.
- Change find package to look for config files
- Link CMakePublic lib
- delete cmake_public:: namespace in helloword.cpp
- Make include relative for cmake_public

* Re-Added return for EOF

* Mov where CMAKE_PREFIX_PATH is defined

* Update CMakeLists
- Update comments
- Chance DCMAKE_PREFIX_PATH to use the actual variable
- Append our cmake config dir to CMAKE_PREFIX_PATH

* Changes to HelloWorld CMakeLists
- Removed use of lib_name
- Added hello-world explicitly for install paths

* Update header path

* update prefix path

* First pass at unit testing
- Added test.cxx no dependency yet
- Added tests/CMakeList to install executable to stage/Debug
- Updated root CMakeList to add test as external project

* Refactor tests
- Remove install step from test by telling it to echo instead
- Rename test.cxx to .cpp
Had to specifiy full file path in add_test to work this way. Not sure how to avoid it.

* Add dependencies to the test
- Fixed args I accidentally deleted from superbuild_core
- Removed the `-` from HelloWorld's install path conflicted with find_package
- Test needed find package for both depenencies.

* Same as last commit - forgot to add

* Fix indentation on 54? Uncomment DEPENDS for test

* replaced if statement to make building of tests optional

* Added comments

* need to print to ctesttestfile but it's getting overwritten

* Fixed `include(CTest)` overwriting CTestTestfile in root cmakelist

* Changed test to test for output rather than returning a `0`.

* working on removing find_package(public) for tests

* same as last

* Create package for helloworld
- Created a template `Config.cmake.in` for package.
- added CMakePublic depenency to package.
- Deleted file name of install(EXPORT).
- Added packaged config line to read template.
- Added install(FILES) for config file.

* - Change install targets to use relative paths
- Change helloworldconfig to be placed in build dir install of install dir
-

* Update some comments

* works on my computer

* Changed preview markdown to relative link to the actual documentation

Co-authored-by: ryan <ryanmrichard1@gmail.com>